### PR TITLE
feat: Add indent options

### DIFF
--- a/packages/composerize-website/src/Main.js
+++ b/packages/composerize-website/src/Main.js
@@ -19,6 +19,7 @@ export default class Main extends Component {
             command: defaultCommand,
             compose: '',
             version: 'latest',
+            indent: 4,
             output: Composerize(defaultCommand),
             error: '',
             erroredLines: [],
@@ -26,6 +27,7 @@ export default class Main extends Component {
         this.onCommandInputChange = this.onCommandInputChange.bind(this);
         this.onComposeInputChange = this.onComposeInputChange.bind(this);
         this.onSelectChange = this.onSelectChange.bind(this);
+        this.onIndentChange = this.onIndentChange.bind(this);
     }
 
     onComposeInputChange(value) {
@@ -49,11 +51,18 @@ export default class Main extends Component {
         this.updateConversion();
     }
 
+    onIndentChange(value) {
+        this.setState(() => ({
+            indent: value.value,
+        }));
+        this.updateConversion();
+    }
+
     updateConversion() {
         this.setState((state) => {
             try {
                 return {
-                    output: Composerize(state.command, state.compose, state.version),
+                    output: Composerize(state.command, state.compose, state.version, state.indent),
                     error: '',
                     erroredLines: [],
                 };
@@ -75,9 +84,11 @@ export default class Main extends Component {
                     command={this.state.command}
                     compose={this.state.compose}
                     version={this.state.version}
+                    indent={this.state.indent}
                     error={this.state.error}
                     erroredLines={this.state.erroredLines}
                     onSelectChange={this.onSelectChange}
+                    onIndentChange={this.onIndentChange}
                     onCommandInputChange={this.onCommandInputChange}
                     onComposeInputChange={this.onComposeInputChange}
                 />

--- a/packages/composerize-website/src/components/Entry.js
+++ b/packages/composerize-website/src/components/Entry.js
@@ -62,12 +62,47 @@ export default function Entry(props) {
                         </p>
                     </Blurb>
                     <TextInput value={props.command} rows={3} onInputChange={props.onCommandInputChange} />
-                    <span>Docker Compose version:</span>
-                    <Select
-                        onChange={props.onSelectChange}
-                        options={options}
-                        value={options.filter(({ value }) => value === props.version)}
-                    />
+                    <div
+                        css={`
+                            display: flex;
+                            gap: 20px;
+                            align-items: center;
+                            margin-top: 10px;
+                        `}
+                    >
+                        <div
+                            css={`
+                                flex: 1;
+                            `}
+                        >
+                            <span>Docker Compose version:</span>
+                            <Select
+                                onChange={props.onSelectChange}
+                                options={options}
+                                value={options.filter(({ value }) => value === props.version)}
+                            />
+                        </div>
+                        <div
+                            css={`
+                                flex: 1;
+                            `}
+                        >
+                            <span>Indentation:</span>
+                            <Select
+                                onChange={props.onIndentChange}
+                                options={[
+                                    { value: 2, label: '2 spaces' },
+                                    { value: 4, label: '4 spaces' },
+                                    { value: 8, label: '8 spaces' },
+                                ]}
+                                value={[
+                                    { value: 2, label: '2 spaces' },
+                                    { value: 4, label: '4 spaces' },
+                                    { value: 8, label: '8 spaces' },
+                                ].filter(({ value }) => value === props.indent)}
+                            />
+                        </div>
+                    </div>
                     <details
                         style={{
                             marginBottom: '1em',

--- a/packages/composerize/__tests__/index.test.js
+++ b/packages/composerize/__tests__/index.test.js
@@ -671,3 +671,67 @@ services:
         image: ilshidur/tor-relay"
 `);
 });
+
+test('indentation is configurable (2 spaces)', () => {
+    const command = 'docker run -p 80:80 foobar/baz:latest';
+
+    expect(Composerize(command, null, 'v3x', 2)).toMatchInlineSnapshot(`
+"version: \\"3\\"
+services:
+  baz:
+    ports:
+      - 80:80
+    image: foobar/baz:latest"
+`);
+});
+
+test('indentation is configurable (4 spaces)', () => {
+    const command = 'docker run -p 80:80 foobar/baz:latest';
+
+    expect(Composerize(command, null, 'v3x', 4)).toMatchInlineSnapshot(`
+"version: \\"3\\"
+services:
+    baz:
+        ports:
+            - 80:80
+        image: foobar/baz:latest"
+`);
+});
+
+test('indentation is configurable (2 spaces) with multiple commands', () => {
+    const command = 'docker run -p 80:80 foobar/baz:latest\ndocker run -p 81:81 foobar/buzz:latest';
+
+    expect(Composerize(command, null, 'latest', 2)).toMatchInlineSnapshot(`
+"name: <your project name>
+services:
+  baz:
+    ports:
+      - 80:80
+    image: foobar/baz:latest
+  buzz:
+    ports:
+      - 81:81
+    image: foobar/buzz:latest"
+`);
+});
+
+test('indentation is configurable (2 spaces) with existing compose', () => {
+    const command = 'docker run -p 80:80 foobar/baz:latest';
+    const existingCompose = `
+version: '3.3'
+services:
+  nginx:
+    image: nginx
+`;
+
+    expect(Composerize(command, existingCompose, 'latest', 2)).toMatchInlineSnapshot(`
+"name: <your project name>
+services:
+  nginx:
+    image: nginx
+  baz:
+    ports:
+      - 80:80
+    image: foobar/baz:latest"
+`);
+});


### PR DESCRIPTION
## Add indent options

I change the UI a little bit, add an options for changing indents.

### Indents: 4 spaces

<img width="1435" height="737" alt="image" src="https://github.com/user-attachments/assets/4fec4c92-9cb9-4453-ba4f-c0f877b95886" />

### Indents: 2 spaces
<img width="1427" height="725" alt="image" src="https://github.com/user-attachments/assets/2572f57c-68c3-411f-a2d1-64e26c09233e" />

I'm a heavily 2 space user. This tools will save me lots of times.
Thanks for authors.

## Checklist

- [x] Added a test to cover this behaviour
- [x] Verified this using the deploy preview
- [x] Behaves according the documentation pasted above