### PR TITLE
Add merging and conflict resolving to CLI

### DIFF
--- a/packages/composerize/__tests__/cli-merge.test.js
+++ b/packages/composerize/__tests__/cli-merge.test.js
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+
+import Composerize from '../src';
+import { composerizeCli } from '../cli-merge';
+
+const existingNginxCompose = ['services:', '  nginx:', '    ports:', '      - 80:80', '    image: nginx:1'].join('\n');
+
+function merge(command, existingDockerCompose, resolveConflicts) {
+    return composerizeCli({
+        command,
+        composerize: Composerize,
+        composeVersion: 'latest',
+        existingDockerCompose,
+        indent: 2,
+        resolveConflicts,
+    });
+}
+
+test('CLI merge deduplicates exact list values', async () => {
+    await expect(merge('docker run -p 80:80 nginx:1', existingNginxCompose)).resolves.toMatchInlineSnapshot(`
+        "name: <your project name>
+        services:
+          nginx:
+            ports:
+              - 80:80
+            image: nginx:1"
+    `);
+});
+
+test('CLI merge can keep both sides of list conflicts', async () => {
+    await expect(
+        merge('docker run -p 81:80 nginx:2', existingNginxCompose, async () => ({
+            'services.nginx.ports': 'both',
+            'services.nginx.image': 'old',
+        })),
+    ).resolves.toMatchInlineSnapshot(`
+        "name: <your project name>
+        services:
+          nginx:
+            ports:
+              - 80:80
+              - 81:80
+            image: nginx:1"
+    `);
+});
+
+test('CLI merge can use generated values for conflicts', async () => {
+    await expect(
+        merge('docker run -p 81:80 nginx:2', existingNginxCompose, async () => ({
+            'services.nginx.ports': 'new',
+            'services.nginx.image': 'new',
+        })),
+    ).resolves.toMatchInlineSnapshot(`
+        "name: <your project name>
+        services:
+          nginx:
+            ports:
+              - 81:80
+            image: nginx:2"
+    `);
+});

--- a/packages/composerize/cli-merge.js
+++ b/packages/composerize/cli-merge.js
@@ -1,0 +1,312 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const tty = require('tty');
+
+const Composeverter = require('composeverter');
+const { Select } = require('enquirer');
+const combos = require('enquirer/lib/combos');
+
+function isPlainObject(value) {
+	return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeForCompare(value) {
+	if (Array.isArray(value)) return value.map(normalizeForCompare);
+	if (!isPlainObject(value)) return value;
+
+	return Object.keys(value).sort().reduce((result, key) => {
+		result[key] = normalizeForCompare(value[key]);
+		return result;
+	}, {});
+}
+
+function valuesAreEqual(left, right) {
+	return JSON.stringify(normalizeForCompare(left)) === JSON.stringify(normalizeForCompare(right));
+}
+
+function dedupeExactArrayValues(value) {
+	if (Array.isArray(value)) {
+		const seen = new Set();
+		const result = [];
+
+		value.forEach((entry) => {
+			const normalizedEntry = JSON.stringify(normalizeForCompare(entry));
+			if (seen.has(normalizedEntry)) return;
+
+			seen.add(normalizedEntry);
+			result.push(dedupeExactArrayValues(entry));
+		});
+
+		return result;
+	}
+
+	if (isPlainObject(value)) {
+		return Object.keys(value).reduce((result, key) => {
+			result[key] = dedupeExactArrayValues(value[key]);
+			return result;
+		}, {});
+	}
+
+	return value;
+}
+
+function formatPath(path) {
+	return path.length ? path.join('.') : '<root>';
+}
+
+function formatValue(value) {
+	if (value === undefined) return '<missing>';
+	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+		return String(value);
+	}
+
+	return Composeverter.yamlStringify(value, { indent: 2 }).trim();
+}
+
+function formatOneLineValue(value) {
+	return formatValue(value)
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.join(' ; ');
+}
+
+function joinConflictLine(conflict, status) {
+	const oldValue = formatOneLineValue(conflict.oldValue);
+	const newValue = formatOneLineValue(conflict.newValue);
+	const prefix = status ? `${status} ` : '';
+	return `${prefix}${formatPath(conflict.path)} | old: ${oldValue} | new: ${newValue}`;
+}
+
+function canKeepBoth(conflict) {
+	return Array.isArray(conflict.oldValue) && Array.isArray(conflict.newValue);
+}
+
+function collectConflicts(oldValue, newValue, path, conflicts) {
+	if (oldValue === undefined || newValue === undefined || valuesAreEqual(oldValue, newValue)) return;
+
+	if (isPlainObject(oldValue) && isPlainObject(newValue)) {
+		Object.keys(newValue).forEach((key) => {
+			if (Object.prototype.hasOwnProperty.call(oldValue, key)) {
+				collectConflicts(oldValue[key], newValue[key], path.concat(key), conflicts);
+			}
+		});
+		return;
+	}
+
+	conflicts.push({
+		path,
+		oldValue,
+		newValue,
+	});
+}
+
+function mergeWithChoices(oldValue, newValue, path, choices) {
+	if (oldValue === undefined) return newValue;
+	if (newValue === undefined || valuesAreEqual(oldValue, newValue)) return oldValue;
+
+	if (isPlainObject(oldValue) && isPlainObject(newValue)) {
+		const result = { ...oldValue };
+		Object.keys(newValue).forEach((key) => {
+			result[key] = mergeWithChoices(oldValue[key], newValue[key], path.concat(key), choices);
+		});
+		return result;
+	}
+
+	const choice = choices[formatPath(path)];
+	if (choice === 'new') return newValue;
+	if (choice === 'both') {
+		if (Array.isArray(oldValue) && Array.isArray(newValue)) return oldValue.concat(newValue);
+		return oldValue;
+	}
+
+	return oldValue;
+}
+
+function splitLeadingComments(yaml) {
+	const lines = yaml.split('\n');
+	const commentLines = [];
+
+	while (lines.length > 0 && (lines[0].trim() === '' || lines[0].trim().startsWith('#'))) {
+		commentLines.push(lines.shift());
+	}
+
+	return {
+		comments: commentLines.join('\n').trim(),
+		yaml: lines.join('\n'),
+	};
+}
+
+function openPromptContext() {
+	if (process.stdin.isTTY) {
+		return {
+			stdin: process.stdin,
+			stdout: process.stderr,
+			close: () => {},
+		};
+	}
+
+	const ttyPath = process.platform === 'win32' ? '\\\\.\\CONIN$' : '/dev/tty';
+	const inputFd = fs.openSync(ttyPath, 'r');
+	const outputFd = fs.openSync(ttyPath, 'w');
+	const input = new tty.ReadStream(inputFd);
+	const output = new tty.WriteStream(outputFd);
+
+	return {
+		stdin: input,
+		stdout: output,
+		close: () => {
+			input.destroy();
+			output.end();
+		},
+	};
+}
+
+async function promptForChoices(conflicts) {
+	let promptHandle;
+
+	try {
+		promptHandle = openPromptContext();
+	} catch (error) {
+		throw new Error('merge conflicts require an interactive terminal to choose old or new values');
+	}
+
+	const choices = {};
+
+	try {
+		promptHandle.stdout.write(`\nMerge conflicts found: ${conflicts.length}\n`);
+
+		while (true) {
+			const conflict = conflicts.find((c) => !choices[formatPath(c.path)]);
+			if (!conflict) return choices;
+
+			const path = formatPath(conflict.path);
+			const conflictIndex = conflicts.indexOf(conflict) + 1;
+
+			const promptChoices = [
+				{ name: 'old', message: 'old - keep old value' },
+				{ name: 'new', message: 'new - use new value' },
+			];
+
+			if (canKeepBoth(conflict)) {
+				promptChoices.push({ name: 'both', message: 'both - keep both values' });
+			}
+
+			if (conflicts.length > 1) {
+				promptChoices.push(
+					{ name: 'all-old', message: 'Keep all old values' },
+					{ name: 'all-new', message: 'Use all new values' },
+				);
+
+				if (conflicts.some((c) => !choices[formatPath(c.path)] && canKeepBoth(c))) {
+					promptChoices.push({ name: 'all-both', message: 'Keep both for all list conflicts' });
+				}
+			}
+
+			const answer = await new Select({
+				name: 'answer',
+				message: `${conflictIndex}/${conflicts.length} ${joinConflictLine(conflict)}`,
+				choices: promptChoices,
+				stdin: promptHandle.stdin,
+				stdout: promptHandle.stdout,
+				actions: {
+					keys: {
+						...combos.keys,
+						o: 'chooseOld',
+						n: 'chooseNew',
+						b: 'chooseBoth',
+					},
+				},
+				chooseOld() {
+					this.index = this.findIndex('old');
+					return this.submit();
+				},
+				chooseNew() {
+					this.index = this.findIndex('new');
+					return this.submit();
+				},
+				chooseBoth() {
+					this.index = this.findIndex('both');
+					return this.submit();
+				},
+			}).run();
+
+			if (answer === 'all-old') {
+				conflicts.forEach((c) => {
+					choices[formatPath(c.path)] = 'old';
+				});
+				return choices;
+			}
+			if (answer === 'all-new') {
+				conflicts.forEach((c) => {
+					choices[formatPath(c.path)] = 'new';
+				});
+				return choices;
+			}
+			if (answer === 'all-both') {
+				conflicts.forEach((c) => {
+					if (canKeepBoth(c)) {
+						choices[formatPath(c.path)] = 'both';
+					}
+				});
+				continue;
+			}
+
+			choices[path] = answer;
+		}
+	} finally {
+		promptHandle.close();
+	}
+}
+
+function normalizeOutputFormat(yaml, composeVersion, indent) {
+	if (composeVersion === 'v2x') return Composeverter.migrateFromV3xToV2x(yaml, { indent });
+	if (composeVersion === 'latest') return Composeverter.migrateToCommonSpec(yaml, { indent });
+	if (composeVersion !== 'v3x') throw new Error(`Unknown ComposeVersion '${composeVersion}'`);
+	return yaml;
+}
+
+async function composerizeCli({
+	command,
+	composerize,
+	composeVersion,
+	existingDockerCompose,
+	indent,
+}) {
+	const generatedOutput = composerize(command, '', composeVersion, indent);
+	const { comments, yaml: generatedYaml } = splitLeadingComments(generatedOutput);
+	const generatedJson = Composeverter.yamlParse(generatedYaml) || {};
+
+	if (!existingDockerCompose) {
+		const yaml = normalizeOutputFormat(
+			Composeverter.yamlStringify(dedupeExactArrayValues(generatedJson), { indent }),
+			composeVersion,
+			indent,
+		).trim();
+		return comments ? `${comments}\n${yaml}` : yaml;
+	}
+
+	const existingJson = Composeverter.yamlParse(existingDockerCompose) || {};
+	const conflicts = [];
+
+	collectConflicts(existingJson, generatedJson, [], conflicts);
+
+	let choices = {};
+	if (conflicts.length > 0) {
+		choices = await promptForChoices(conflicts);
+	}
+
+	const mergedJson = dedupeExactArrayValues(mergeWithChoices(existingJson, generatedJson, [], choices));
+	const mergedYaml = normalizeOutputFormat(
+		Composeverter.yamlStringify(mergedJson, { indent }),
+		composeVersion,
+		indent,
+	).trim();
+
+	return comments ? `${comments}\n${mergedYaml}` : mergedYaml;
+}
+
+module.exports = {
+	composerizeCli,
+};

--- a/packages/composerize/cli-merge.js
+++ b/packages/composerize/cli-merge.js
@@ -273,6 +273,7 @@ async function composerizeCli({
 	composeVersion,
 	existingDockerCompose,
 	indent,
+	resolveConflicts = promptForChoices,
 }) {
 	const generatedOutput = composerize(command, '', composeVersion, indent);
 	const { comments, yaml: generatedYaml } = splitLeadingComments(generatedOutput);
@@ -294,7 +295,7 @@ async function composerizeCli({
 
 	let choices = {};
 	if (conflicts.length > 0) {
-		choices = await promptForChoices(conflicts);
+		choices = await resolveConflicts(conflicts);
 	}
 
 	const mergedJson = dedupeExactArrayValues(mergeWithChoices(existingJson, generatedJson, [], choices));

--- a/packages/composerize/cli.js
+++ b/packages/composerize/cli.js
@@ -2,6 +2,7 @@
 /* eslint-disable */
 
 const composerize = require('./dist/composerize');
+const { composerizeCli } = require('./cli-merge');
 const argv = require('yargs-parser')(process.argv.slice(2), {
 	configuration: {
 		'halt-at-non-option': true,
@@ -9,6 +10,9 @@ const argv = require('yargs-parser')(process.argv.slice(2), {
 });
 
 const command = argv['_'].join(' ');
+const composeVersion = argv.format || argv.f || 'latest';
+const indent = Number(argv.indent || argv.i || 2);
+
 if (argv.help || argv.h)
 {
 	console.log(`
@@ -26,14 +30,29 @@ composerize -i 4 -f v2x docker run -p 80:80 -v /var/run/docker.sock:/tmp/docker.
 	process.exit();
 }
 
+function printOutput(existingDockerCompose) {
+	composerizeCli({
+		command,
+		composerize,
+		composeVersion,
+		existingDockerCompose,
+		indent,
+	})
+		.then((output) => console.log(output))
+		.catch((error) => {
+			console.error(error.message);
+			process.exit(1);
+		});
+}
+
 if (process.stdin.isTTY){
-	console.log(composerize(command, '', argv.format || argv.f || 'latest', argv.indent || argv.i || 2));
+	printOutput('');
 }
 else {
 	var existingDockerCompose = '';
 	process.stdin.on('data', function(d) {
 		existingDockerCompose += d;
 	}).on('end', function() {
-		console.log(composerize(command, existingDockerCompose, argv.format || argv.f || 'latest', argv.indent || argv.i || 2));
+		printOutput(existingDockerCompose);
 	}).setEncoding('utf8');
 }

--- a/packages/composerize/package.json
+++ b/packages/composerize/package.json
@@ -35,11 +35,13 @@
     "composeverter": "latest",
     "core-js": "^2.5.5",
     "deepmerge": "^2.1.0",
+    "enquirer": "^2.4.1",
     "invariant": "^2.2.4",
     "yargs-parser": "^13.0.0"
   },
   "files": [
     "dist/composerize.js",
+    "cli-merge.js",
     "cli.js"
   ],
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,6 +5477,14 @@ enhanced-resolve@^5.17.2:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+enquirer@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
+  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
+  dependencies:
+    ansi-colors "^4.1.1"
+    strip-ansi "^6.0.1"
+
 enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -12225,7 +12233,16 @@ string-range@~1.2, string-range@~1.2.1:
   resolved "https://registry.yarnpkg.com/string-range/-/string-range-1.2.2.tgz#a893ed347e72299bc83befbbf2a692a8d239d5dd"
   integrity sha512-tYft6IFi8SjplJpxCUxyqisD3b+R2CSkomrtJYCkvuf1KuCAWgz7YXt4O0jip7efpfCemwHEzTEAO8EuOYgh3w==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12339,7 +12356,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13684,7 +13708,7 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13697,6 +13721,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Improves the CLI merge path when an existing Compose file is piped through stdin. Exact duplicate list values are deduplicated, differing values are shown as compact interactive conflicts, and list conflicts can keep both old and new values.

The library/API output is unchanged; this only affects the interactive CLI merge flow.

## Example

### Duplicate list values are deduplicated

**Input:** `printf '%s\n' "services:" "  nginx:" "    ports:" "      - 80:80" "    image: nginx:1" | packages/composerize/cli.js docker run -p 80:80 nginx:1`

**Output:**
```yaml
name: <your project name>
services:
  nginx:
    ports:
      - 80:80
    image: nginx:1
```

### Conflicting values are resolved interactively

**Input:** `printf '%s\n' "services:" "  nginx:" "    ports:" "      - 80:80" "    image: nginx:1" | packages/composerize/cli.js docker run -p 81:80 nginx:2`

When prompted, choose `both` for `services.nginx.ports` and `old` for `services.nginx.image`.

**Output:**
```yaml
name: <your project name>
services:
  nginx:
    ports:
      - 80:80
      - 81:80
    image: nginx:1
```

The conflict prompt shows each submitted choice once:

```text
Merge conflicts found: 2
✔ 1/2 services.nginx.ports | old: - 80:80 | new: - 81:80 · both
✔ 2/2 services.nginx.image | old: nginx:1 | new: nginx:2 · old
```

If the user chooses `new` for both conflicts instead, the merge uses the generated values:

```yaml
name: <your project name>
services:
  nginx:
    ports:
      - 81:80
    image: nginx:2
```

## Relevant Docker Documentation

**Docker CLI:** https://docs.docker.com/reference/cli/docker/container/run/#publish
**Docker Compose:** https://docs.docker.com/reference/compose-file/services/#ports

## Checklist

- [x] Added a test to cover this behaviour
- [ ] Verified this using the deploy preview
- [x] Behaves according the documentation pasted above

## Notes

Deploy preview verification is left unchecked because this change only affects the interactive CLI merge flow.

Manual verification run locally:

```bash
yarn workspace composerize run eslint cli.js cli-merge.js __tests__/cli-merge.test.js --format codeframe
yarn workspace composerize jest --no-watchman
yarn workspace composerize build
```
